### PR TITLE
Remove iteration in favorite list

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,12 @@
         </section>
         <section class="flip-card-back" id="flip-card-back">
           <div id="back-card-words">
-            <h2 id="favorite-affirmations-list">Favorite Affirmations</h2>
-            <h2 id="favorite-mantras-list">Favorite Mantras</h2>
+            <section id="favorite-affirmations-list">
+              <h2>Favorite Affirmations</h2>
+            </section>
+            <section id="favorite-mantras-list">
+              <h2>Favorite Mantras</h2>
+            </section>
             <p id="back-to-main-link" class="back-to-main clear-message-link">Back to main</p>
           </div>
         </section>

--- a/main.js
+++ b/main.js
@@ -154,12 +154,12 @@ const addFavoriteMessage = () => {
     hide([favoriteButton])
     show([addedMessage, favoriteMessagesLink])
     favoriteMantras.push(userMessage.textContent)
-    console.log(favoriteMantras)
+    listFavoriteMantras(userMessage.textContent)
   } else {
     hide([favoriteButton])
     show([addedMessage, favoriteMessagesLink])
     favoriteAffirmations.push(userMessage.textContent)
-    console.log(favoriteAffirmations)
+    listFavoritesAffirmations(userMessage.textContent)
   }
 }
 
@@ -167,12 +167,14 @@ const flipCard = () => {
   firstContainer.classList.remove('spin-back')
   secondContainer.classList.remove('spin-back')
   flip([firstContainer, secondContainer, backOfCardWords])
-  favoriteAffirmations.forEach(affirmation => {
-    favoriteAffirmationsList.insertAdjacentHTML('beforeend', `<p class="favorite-list">${affirmation}<p>`)
-  })
-  favoriteMantras.forEach(mantra => {
-    favoriteMantrasList.insertAdjacentHTML('beforeend', `<p class="favorite-list">${mantra}<p>`)
-  })
+}
+
+const listFavoritesAffirmations = (affirmation) => {
+      favoriteAffirmationsList.innerHTML += `<p class="favorite-list">${affirmation}<p>`
+}
+
+const listFavoriteMantras = (mantra) => {
+    favoriteMantrasList.innerHTML += `<p class="favorite-list">${mantra}<p>`
 }
 
 let flipBackToMainView = () => {


### PR DESCRIPTION
This PR removes the duplicates in the favorite lists by removing the iterating every time a favorite was clicked, so that it didn't list the entire list over again, but only what the user clicked to add to the list.